### PR TITLE
Updated pcsc-sharp to PCSC 4.0.0 and added support for RAW protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,11 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+\.vs/ThaiNationalIDCard/v15/Server/sqlite3/db\.lock
+
+\.vs/ThaiNationalIDCard/v15/Server/sqlite3/storage\.ide
+
+\.vs/ThaiNationalIDCard/v15/Server/sqlite3/storage\.ide-shm
+
+\.vs/ThaiNationalIDCard/v15/Server/sqlite3/storage\.ide-wal

--- a/ThaiNationalIDCard/ThaiIDCard.cs
+++ b/ThaiNationalIDCard/ThaiIDCard.cs
@@ -1,7 +1,7 @@
 ﻿/* BSD license
  * Credit:  APDU Command from Mr.Manoi http://hosxp.net/index.php?option=com_smf&topic=22496
  * Require add reference: PresentationCore, System.Xaml, WindowsBase
- * Require add refrernce(Nuget): PCSC ( http://www.nuget.org/packages/PCSC/ )
+ * Require add refrernce(Nuget): PCSC ( http://www.nuget.org/packages/PCSC/ ) and PCSC.Iso7816 ( https://www.nuget.org/packages/PCSC.Iso7816/ )
  */
 
 using System;
@@ -12,6 +12,9 @@ using PCSC;
 using PCSC.Iso7816;
 using System.Diagnostics;
 using System.Threading;
+using PCSC.Monitoring;
+using PCSC.Exceptions;
+using PCSC.Utils;
 
 namespace ThaiNationalIDCard
 {
@@ -264,6 +267,9 @@ namespace ThaiNationalIDCard
                         break;
                     case SCardProtocol.T1:
                         _pioSendPci = SCardPCI.T1;
+                        break;
+                    case SCardProtocol.Raw:
+                        _pioSendPci = SCardPCI.Raw;
                         break;
                     default:
                         throw new PCSCException(SCardError.ProtocolMismatch,

--- a/ThaiNationalIDCard/ThaiNationalIDCard.csproj
+++ b/ThaiNationalIDCard/ThaiNationalIDCard.csproj
@@ -80,8 +80,11 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="pcsc-sharp, Version=3.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCSC.3.7.0\lib\net40\pcsc-sharp.dll</HintPath>
+    <Reference Include="PCSC, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCSC.4.0.0\lib\net40\PCSC.dll</HintPath>
+    </Reference>
+    <Reference Include="PCSC.Iso7816, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCSC.Iso7816.4.0.0\lib\net40\PCSC.Iso7816.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />

--- a/ThaiNationalIDCard/packages.config
+++ b/ThaiNationalIDCard/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="PCSC" version="3.7.0" targetFramework="net40" />
+  <package id="PCSC" version="4.0.0" targetFramework="net40" />
+  <package id="PCSC.Iso7816" version="4.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
- Updated PCSC to 4.0.0
- "pcsc-sharp" is now obsolete and replaced with PCSC (Nuget: https://www.nuget.org/packages/PCSC/ ) and PCSC.Iso7816 (Nuget: https://www.nuget.org/packages/PCSC.Iso7816/ )
- Added support to RAW protocol to handle legacy card readers (e.g. ACR38U-SPC)